### PR TITLE
Feature/bc-update-hdc-error-detail-response

### DIFF
--- a/src/Microsoft.Devices.HardwareDevCenterManager/DevCenterHandler.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/DevCenterHandler.cs
@@ -138,6 +138,7 @@ namespace Microsoft.Devices.HardwareDevCenterManager.DevCenterApi
                     }
 
                     string content = await infoResult.Content.ReadAsStringAsync();
+
                     if (infoResult.IsSuccessStatusCode)
                     {
                         processContent?.Invoke(content);
@@ -182,12 +183,16 @@ namespace Microsoft.Devices.HardwareDevCenterManager.DevCenterApi
 
                 if (reterr.Error != null)
                 {
+                    // include addtional error details if missing from deserialization
+                    reterr.Error.HttpErrorCode = (int)infoResult.StatusCode;
+                    reterr.Error.Trace = trace;
+
                     return reterr.Error;
                 }
 
                 return new DevCenterErrorDetails
                 {
-                    HttpErrorCode = reterr.HttpErrorCode,
+                    HttpErrorCode = (int)infoResult.StatusCode,
                     Code = reterr.StatusCode,
                     Message = reterr.Message,
                     ValidationErrors = reterr.ValidationErrors,

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.0.0</Version>
+    <Version>2.0.4</Version>
     <Authors>Microsoft</Authors>
     <Description>Class library used in invoking HTTP requests to the Hardware Dev Center dashboard API</Description>
     <Copyright>&amp;#169; Microsoft Corporation. All rights reserved.</Copyright>


### PR DESCRIPTION
This update adds additional error details to be returned in the response. Previously only HDC code and message were returned. The response now includes the HDC error code, message, validation errors, HTTP status code, and trace.

This allows for more ways to handle errors when returned to your service.