### PR TITLE
Feature/bc-update-http-response-logic

### DIFF
--- a/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.0.5</Version>
+    <Version>3.0.0</Version>
     <Authors>Microsoft</Authors>
     <Description>Class library used in invoking HTTP requests to the Hardware Dev Center dashboard API</Description>
     <Copyright>&amp;#169; Microsoft Corporation. All rights reserved.</Copyright>

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.0.4</Version>
+    <Version>2.0.5</Version>
     <Authors>Microsoft</Authors>
     <Description>Class library used in invoking HTTP requests to the Hardware Dev Center dashboard API</Description>
     <Copyright>&amp;#169; Microsoft Corporation. All rights reserved.</Copyright>

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.0.0</Version>
+    <Version>2.1.0</Version>
     <Authors>Microsoft</Authors>
     <Description>Class library used in invoking HTTP requests to the Hardware Dev Center dashboard API</Description>
     <Copyright>&amp;#169; Microsoft Corporation. All rights reserved.</Copyright>

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterErrorDetails.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterErrorDetails.cs
@@ -5,11 +5,16 @@
 --*/
 using Newtonsoft.Json;
 using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace Microsoft.Devices.HardwareDevCenterManager.DevCenterApi
 {
     public class DevCenterErrorDetails
     {
+        [JsonProperty("headers")]
+        public HttpResponseHeaders Headers { get; set; }
+
         [JsonProperty("code")]
         public string Code { get; set; }
 


### PR DESCRIPTION
this update remove retires and handling of HTTP 429 and 5xx responses, consumer can handle in their implementation which provides more control.