### PR TITLE
feature/bc-add-correlation-and-request-ids-to-all-responses 

### DIFF
--- a/src/Microsoft.Devices.HardwareDevCenterManager/DevCenterHandler.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/DevCenterHandler.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Devices.HardwareDevCenterManager.DevCenterApi
         private readonly AuthorizationHandlerCredentials AuthCredentials;
         private readonly TimeSpan HttpTimeout;
         private Guid CorrelationId;
+        private readonly LastCommandDelegate LastCommand;
         private DevCenterTrace Trace;
 
         /// <summary>
@@ -32,6 +33,7 @@ namespace Microsoft.Devices.HardwareDevCenterManager.DevCenterApi
             AuthHandler = new AuthorizationHandler(AuthCredentials, options.HttpTimeoutSeconds);
             HttpTimeout = TimeSpan.FromSeconds(options.HttpTimeoutSeconds);
             CorrelationId = options.CorrelationId;
+            LastCommand = options.LastCommand;
         }
 
         private string GetDevCenterBaseUrl()
@@ -73,6 +75,11 @@ namespace Microsoft.Devices.HardwareDevCenterManager.DevCenterApi
                     Url = uri,
                     Content = json
                 };
+
+                LastCommand?.Invoke(new DevCenterErrorDetails()
+                {
+                    Trace = Trace
+                });
 
                 client.Timeout = HttpTimeout;
                 Uri restApi = new Uri(uri);

--- a/src/Microsoft.Devices.HardwareDevCenterManager/DevCenterOptions.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/DevCenterOptions.cs
@@ -13,8 +13,5 @@ namespace Microsoft.Devices.HardwareDevCenterManager
         public uint HttpTimeoutSeconds { get; set; }
         public int RequestDelayMs { get; set; }
         public Guid CorrelationId { get; set; }
-        public LastCommandDelegate LastCommand { get; set; }
     }
-
-    public delegate void LastCommandDelegate(DevCenterErrorDetails error);
 }

--- a/src/Microsoft.Devices.HardwareDevCenterManager/DevCenterOptions.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/DevCenterOptions.cs
@@ -3,7 +3,6 @@
 
     Licensed under the MIT license.  See LICENSE file in the project root for full license information.  
 --*/
-using Microsoft.Devices.HardwareDevCenterManager.DevCenterApi;
 using System;
 
 namespace Microsoft.Devices.HardwareDevCenterManager

--- a/src/Microsoft.Devices.HardwareDevCenterManager/DevCenterOptions.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/DevCenterOptions.cs
@@ -3,6 +3,7 @@
 
     Licensed under the MIT license.  See LICENSE file in the project root for full license information.  
 --*/
+using Microsoft.Devices.HardwareDevCenterManager.DevCenterApi;
 using System;
 
 namespace Microsoft.Devices.HardwareDevCenterManager
@@ -12,5 +13,8 @@ namespace Microsoft.Devices.HardwareDevCenterManager
         public uint HttpTimeoutSeconds { get; set; }
         public int RequestDelayMs { get; set; }
         public Guid CorrelationId { get; set; }
+        public LastCommandDelegate LastCommand { get; set; }
     }
+
+    public delegate void LastCommandDelegate(DevCenterErrorDetails error);
 }

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterErrorDetails.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterErrorDetails.cs
@@ -25,6 +25,9 @@ namespace Microsoft.Devices.HardwareDevCenterManager.DevCenterApi
 
         [JsonProperty("httpErrorCode")]
         public int? HttpErrorCode { get; set; }
+
+        [JsonProperty("trace")]
+        public DevCenterTrace Trace { get; set; }
     }
 
     public class DevCenterErrorValidationErrorEntry

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterErrorDetails.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterErrorDetails.cs
@@ -5,7 +5,6 @@
 --*/
 using Newtonsoft.Json;
 using System.Collections.Generic;
-using System.Net.Http;
 using System.Net.Http.Headers;
 
 namespace Microsoft.Devices.HardwareDevCenterManager.DevCenterApi
@@ -26,20 +25,6 @@ namespace Microsoft.Devices.HardwareDevCenterManager.DevCenterApi
 
         [JsonProperty("httpErrorCode")]
         public int? HttpErrorCode { get; set; }
-
-        public DevCenterErrorTrace Trace;
-    }
-
-    public class DevCenterErrorTrace
-    {
-        [JsonProperty("requestId")]
-        public string RequestId { get; set; }
-        [JsonProperty("url")]
-        public string Url { get; set; }
-        [JsonProperty("content")]
-        public string Content { get; set; }
-        [JsonProperty("method")]
-        public string Method { get; set; }
     }
 
     public class DevCenterErrorValidationErrorEntry

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterResponse.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterResponse.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Devices.HardwareDevCenterManager.DevCenterApi
     public class DevCenterResponse<T>
     {
         public DevCenterErrorDetails Error { get; set; }
+        public DevCenterTrace Trace { get; set; }
         public List<T> ReturnValue { get; set; }
     }
 }

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterTrace.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterTrace.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace Microsoft.Devices.HardwareDevCenterManager.DevCenterApi
+{
+    public class DevCenterTrace
+    {
+        [JsonProperty("correlationId")]
+        public string CorrelationId { get; set; }
+
+        [JsonProperty("requestId")]
+        public string RequestId { get; set; }
+
+        [JsonProperty("url")]
+        public string Url { get; set; }
+
+        [JsonProperty("content")]
+        public string Content { get; set; }
+
+        [JsonProperty("method")]
+        public string Method { get; set; }
+    }
+}


### PR DESCRIPTION
This update removes DevCenterErrorTrace (previously in DevCenterErrorDetails) and adds DevCenterTrace which is now in the DevCenterHandler. This becomes a general trace to be returned with both successful and failed API calls allowing consumers of the library to log all calls with correlation and request IDs.
