### PR TITLE
Create dotnet-pr-build-validation.yml

### DIFF
--- a/.github/workflows/dotnet-pr-build-validation.yml
+++ b/.github/workflows/dotnet-pr-build-validation.yml
@@ -1,0 +1,28 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: .NET
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/dotnet-pr-build-validation.yml
+++ b/.github/workflows/dotnet-pr-build-validation.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -20,9 +19,15 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
+        
     - name: Restore dependencies
       run: dotnet restore
+      working-directory: './src/Microsoft.Devices.HardwareDevCenterManager/'
+      
     - name: Build
       run: dotnet build --no-restore
+      working-directory: './src/Microsoft.Devices.HardwareDevCenterManager/'
+      
     - name: Test
       run: dotnet test --no-build --verbosity normal
+      working-directory: './src/Microsoft.Devices.HardwareDevCenterManager/'

--- a/.github/workflows/dotnet-pr-build-validation.yml
+++ b/.github/workflows/dotnet-pr-build-validation.yml
@@ -1,7 +1,7 @@
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
-name: .NET
+name: .NET Build Validation
 
 on:
   push:


### PR DESCRIPTION
# Why
We should reintroduce build validations. +Trying out Actions.

# What Changed
Adding action workflow to validate builds in GitHub versus Azure DevOps.
