### PR TITLE
Update shipping label dump - targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,54 @@
+# __Microsoft.Devices.HardwareDevCenterManager__
 
-# Contributing
+![Nuget](https://img.shields.io/nuget/v/Microsoft.Devices.HardwareDevCenterManager)
+![Nuget](https://img.shields.io/nuget/dt/Microsoft.Devices.HardwareDevCenterManager)
+[![Build Validation](https://github.com/microsoft/devices-hardware-dev-center-manager/actions/workflows/dotnet-pr-build-validation.yml/badge.svg)](https://github.com/microsoft/devices-hardware-dev-center-manager/actions/workflows/dotnet-pr-build-validation.yml)
+
+Class library used in invoking HTTP requests to the [Hardware Dev Center dashboard API](https://learn.microsoft.com/en-us/windows-hardware/drivers/dashboard/dashboard-api)
+
+---
+
+## __Features__
+### Manage Products
+```csharp
+DevCenterResponse<Product> response = await api.NewProduct(json);
+DevCenterResponse<Product> response = await api.GetProducts(ProductId);
+```
+---
+
+### Manage Submissions
+```csharp
+DevCenterResponse<Submission> response = await api.NewSubmission(ProductId, json);
+DevCenterResponse<bool> response = await api.CommitSubmission(ProductId, SubmissionId);
+DevCenterResponse<Submission> response = await api.GetSubmission(ProductId, SubmissionId);
+```
+
+---
+
+### Manage Shipping Labels
+```csharp
+DevCenterResponse<ShippingLabel> response = await api.NewShippingLabel(ProductId, SubmissionId, json);
+DevCenterResponse<ShippingLabel> response = await api.GetShippingLabels(ProductId, SubmissionId, ShippingLabelId);
+```
+
+---
+
+### Download Packages
+```csharp
+DevCenterResponse<Submission> response = await api.GetSubmission(ProductId, SubmissionId);
+// use download links from submission resource
+```
+
+---
+
+### Create Metadata
+```csharp
+DevCenterResponse<bool> response = await api.CreateMetaData(ProductId, SubmissionId);
+```
+
+---
+
+## __Contributing__
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>2.2.12</Version>
+    <Version>2.2.13</Version>
     <Authors>Microsoft</Authors>
     <Description>Class library used in invoking HTTP requests to the Hardware Dev Center dashboard API</Description>
-    <Copyright>&amp;#169; Microsoft Corporation. All rights reserved.</Copyright>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/microsoft/devices-hardware-dev-center-manager</PackageProjectUrl>
     <RepositoryUrl>https://github.com/microsoft/devices-hardware-dev-center-manager</RepositoryUrl>

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/ShippingLabel.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/ShippingLabel.cs
@@ -72,34 +72,58 @@ namespace Microsoft.Devices.HardwareDevCenterManager.DevCenterApi
             Console.WriteLine("         Targeting:");
             if (Targeting != null)
             {
+                // hardware ids
                 Console.WriteLine("           hardwareIds:");
-                foreach (HardwareId hid in Targeting.HardwareIds)
+                if (Targeting.HardwareIds.Count > 0)
                 {
-                    Console.WriteLine("           bundledId: " + hid.BundleId);
-                    Console.WriteLine("           infId:     " + hid.InfId);
-                    Console.WriteLine("           operatingSystemCode: " + hid.OperatingSystemCode);
-                    Console.WriteLine("           pnpString: " + hid.PnpString);
-                    Console.WriteLine("           distributionsState:  " + hid.DistributionState);
+                    foreach (HardwareId hid in Targeting.HardwareIds)
+                    {
+                        Console.WriteLine("           bundledId: " + hid.BundleId);
+                        Console.WriteLine("           infId:     " + hid.InfId);
+                        Console.WriteLine("           operatingSystemCode: " + hid.OperatingSystemCode);
+                        Console.WriteLine("           pnpString: " + hid.PnpString);
+                        Console.WriteLine("           distributionsState:  " + hid.DistributionState);
+                    }
                 }
+
+                // chids
                 Console.WriteLine("           chids:");
-                foreach (CHID chid in Targeting.Chids)
+                if (Targeting.Chids.Count > 0)
                 {
-                    Console.WriteLine("           chid: " + chid.Chid);
-                    Console.WriteLine("           distributionState: " + chid.DistributionState);
+                    foreach (CHID chid in Targeting.Chids)
+                    {
+                        Console.WriteLine("           chid: " + chid.Chid);
+                        Console.WriteLine("           distributionState: " + chid.DistributionState);
+                    }
                 }
+
+                // audiences
                 Console.WriteLine("           restrictedToAudiences:");
-                foreach (string audience in Targeting.RestrictedToAudiences)
+                if (Targeting.RestrictedToAudiences.Count > 0)
                 {
-                    Console.WriteLine("           " + audience);
+                    foreach (string audience in Targeting.RestrictedToAudiences)
+                    {
+                        Console.WriteLine("           " + audience);
+                    }
                 }
+
+                //  in service publish information
                 Console.WriteLine("           inServicePublishInfo:");
-                Console.WriteLine("               flooring: " + Targeting.InServicePublishInfo.Flooring);
-                Console.WriteLine("               ceiling:  " + Targeting.InServicePublishInfo.Ceiling);
+                if (Targeting.InServicePublishInfo != null)
+                {
+                    Console.WriteLine("               flooring: " + Targeting.InServicePublishInfo.Flooring);
+                    Console.WriteLine("               ceiling:  " + Targeting.InServicePublishInfo.Ceiling);
+                }
+
+                //  co-engineering driver publish information
                 Console.WriteLine("           coEngDriverPublishInfo:");
-                Console.WriteLine("               flooringBuildNumber: " + Targeting.CoEngDriverPublishInfo.FlooringBuildNumber);
-                Console.WriteLine("               ceilingBuildNumber:  " + Targeting.CoEngDriverPublishInfo.CeilingBuildNumber);
+                if (Targeting.CoEngDriverPublishInfo != null)
+                {
+                    Console.WriteLine("               flooringBuildNumber: " + Targeting.CoEngDriverPublishInfo.FlooringBuildNumber);
+                    Console.WriteLine("               ceilingBuildNumber:  " + Targeting.CoEngDriverPublishInfo.CeilingBuildNumber);
+                }
             }
-           
+
             Console.WriteLine("         Links:");
             if (Links != null)
             {
@@ -108,7 +132,7 @@ namespace Microsoft.Devices.HardwareDevCenterManager.DevCenterApi
                     link.Dump();
                 }
             }
-            
+
             Console.WriteLine("         Status:");
             if (WorkflowStatus != null)
             {


### PR DESCRIPTION
## Why
Shipping label dump would throw exception if `inServicePublishInfo` was null. There was not a check for this specifically.

## What Changed
1. Add additional null and empty list checks for `Targeting` object
1. Updated `version` to  `2.2.13` 

## Additional Changes
1. Updated `<Copyright>` with character to display correctly on NuGet.org
1. Updated `README.md` for improvements