### PR TITLE
Fix shipping label list and create issues where IDs are type long

### DIFF
--- a/src/Microsoft.Devices.HardwareDevCenterManager/DevCenterHandler.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/DevCenterHandler.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using Microsoft.Devices.HardwareDevCenterManager.Utility;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
@@ -9,7 +9,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/microsoft/devices-hardware-dev-center-manager</PackageProjectUrl>
     <RepositoryUrl>https://github.com/microsoft/devices-hardware-dev-center-manager</RepositoryUrl>
-    <LangVersion>11</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
@@ -17,14 +17,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.42.0" />
-    <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.21.1" />
-    <PackageReference Include="Azure.Storage.Files.Shares" Version="12.19.1" />
+    <PackageReference Include="Azure.Core" Version="1.44.1" />
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
+    <PackageReference Include="Azure.Storage.Files.Shares" Version="12.21.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.1" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="System.Text.Json" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
@@ -9,7 +9,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageProjectUrl>https://github.com/microsoft/devices-hardware-dev-center-manager</PackageProjectUrl>
     <RepositoryUrl>https://github.com/microsoft/devices-hardware-dev-center-manager</RepositoryUrl>
-    <LangVersion>10</LangVersion>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.0.0</Version>
+    <Version>3.0.16</Version>
     <Authors>Microsoft</Authors>
     <Description>Class library used in invoking HTTP requests to the Hardware Dev Center dashboard API</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.0.16</Version>
+    <Version>3.0.17</Version>
     <Authors>Microsoft</Authors>
     <Description>Class library used in invoking HTTP requests to the Hardware Dev Center dashboard API</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Microsoft.Devices.HardwareDevCenterManager.csproj
@@ -17,14 +17,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.44.1" />
+    <PackageReference Include="Azure.Core" Version="1.45.0" />
     <PackageReference Include="Azure.Identity" Version="1.13.2" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
-    <PackageReference Include="Azure.Storage.Files.Shares" Version="12.21.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
+    <PackageReference Include="Azure.Storage.Files.Shares" Version="12.22.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.3" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.1" />
+    <PackageReference Include="System.Text.Json" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/AdditionalAttributes.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/AdditionalAttributes.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/AdditionalInfoForMsApproval.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/AdditionalInfoForMsApproval.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System.Collections.Generic;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/Audience.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/Audience.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/CHID.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/CHID.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/CoEngDriverPublishInfo.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/CoEngDriverPublishInfo.cs
@@ -1,18 +1,21 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
+using Microsoft.Devices.HardwareDevCenterManager.Utility;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Devices.HardwareDevCenterManager.DevCenterApi;
 
 public class CoEngDriverPublishInfo
 {
+    [JsonConverter(typeof(LongToStringJsonConverter))]
     [JsonPropertyName("flooringBuildNumber")]
     public string FlooringBuildNumber { get; set; }
 
+    [JsonConverter(typeof(LongToStringJsonConverter))]
     [JsonPropertyName("ceilingBuildNumber")]
     public string CeilingBuildNumber { get; set; }
 }

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterErrorDetails.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterErrorDetails.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System.Collections.Generic;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterErrorReturn.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterErrorReturn.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System.Collections.Generic;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterResponse.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/DevCenterResponse.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System.Collections.Generic;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/Download.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/Download.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/DriverMetadata.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/DriverMetadata.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/HardwareId.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/HardwareId.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/InServicePublishInfo.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/InServicePublishInfo.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/Link.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/Link.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/NewShippingLabel.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/NewShippingLabel.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/Product.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/Product.cs
@@ -114,15 +114,14 @@ public class Product : IArtifact
         Console.WriteLine("         testHarness: " + TestHarness ?? "");
         Console.WriteLine("         message: " + Message ?? "");
 
-        if (string.IsNullOrWhiteSpace(SourcePublisherId))
+        if (!string.IsNullOrWhiteSpace(SourcePublisherId))
         {
             Console.WriteLine("         Source Publisher:    " + SourcePublisherId ?? "");
         }
-        if (string.IsNullOrWhiteSpace(SourceProductId))
+        if (!string.IsNullOrWhiteSpace(SourceProductId))
         {
             Console.WriteLine("         Source Product Id:    " + SourceProductId ?? "");
         }
-
         Console.WriteLine("         Signatures:");
         foreach (string sig in RequestedSignatures)
         {

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/Product.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/Product.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using Microsoft.Devices.HardwareDevCenterManager.Utility;
@@ -22,6 +22,14 @@ public class Product : IArtifact
     [JsonPropertyName("sharedProductId")]
     public string SharedProductId { get; set; }
 
+    [JsonConverter(typeof(LongToStringJsonConverter))]
+    [JsonPropertyName("sourceProductId")]
+    public string SourceProductId { get; set; }
+
+    [JsonConverter(typeof(LongToStringJsonConverter))]
+    [JsonPropertyName("sourcePublisherId")]
+    public string SourcePublisherId { get; set; }
+
     [JsonPropertyName("productName")]
     public string ProductName { get; set; }
 
@@ -33,12 +41,6 @@ public class Product : IArtifact
 
     [JsonPropertyName("deviceType")]
     public string DeviceType { get; set; }
-
-    [JsonPropertyName("isTestSign")]
-    public bool IsTestSign { get; set; }
-
-    [JsonPropertyName("isFlightSign")]
-    public bool IsFlightSign { get; set; }
 
     [JsonPropertyName("requestedSignatures")]
     public List<string> RequestedSignatures { get; set; }
@@ -70,6 +72,12 @@ public class Product : IArtifact
     [JsonPropertyName("selectedProductTypes")]
     public Dictionary<string, string> SelectedProductTypes { get; set; }
 
+    [JsonPropertyName("isTestSign")]
+    public bool IsTestSign { get; set; }
+
+    [JsonPropertyName("isFlightSign")]
+    public bool IsFlightSign { get; set; }
+
     [JsonPropertyName("isCommitted")]
     public bool IsCommitted { get; set; }
 
@@ -78,6 +86,12 @@ public class Product : IArtifact
 
     [JsonPropertyName("additionalAttributes")]
     public AdditionalAttributes AdditionalAttributes { get; set; }
+
+    [JsonPropertyName("links")]
+    public List<Link> Links { get; set; }
+
+    [JsonPropertyName("message")]
+    public string Message { get; set; }
 
     public void Dump()
     {
@@ -98,6 +112,16 @@ public class Product : IArtifact
         Console.WriteLine("         updatedDateTime:  " + UpdatedDateTime.ToString("s", CultureInfo.CurrentCulture));
         Console.WriteLine("         announcementDate: " + AnnouncementDate.ToString("s", CultureInfo.CurrentCulture));
         Console.WriteLine("         testHarness: " + TestHarness ?? "");
+        Console.WriteLine("         message: " + Message ?? "");
+
+        if (string.IsNullOrWhiteSpace(SourcePublisherId))
+        {
+            Console.WriteLine("         Source Publisher:    " + SourcePublisherId ?? "");
+        }
+        if (string.IsNullOrWhiteSpace(SourceProductId))
+        {
+            Console.WriteLine("         Source Product Id:    " + SourceProductId ?? "");
+        }
 
         Console.WriteLine("         Signatures:");
         foreach (string sig in RequestedSignatures)
@@ -162,6 +186,15 @@ public class Product : IArtifact
                 Console.WriteLine("         svvp:");
                 Console.WriteLine("             maxProcessors: " + AdditionalAttributes.Svvp.MaxProcessors);
                 Console.WriteLine("             maxMemory:     " + AdditionalAttributes.Svvp.MaxMemory);
+            }
+        }
+
+        Console.WriteLine("         Links:");
+        if (Links != null)
+        {
+            foreach (Link link in Links)
+            {
+                link.Dump();
             }
         }
         Console.WriteLine();

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/PublishingSpecifications.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/PublishingSpecifications.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System;
@@ -16,7 +16,7 @@ public class PublishingSpecifications
     public DateTime GoLiveDate { get; set; }
 
     [JsonPropertyName("visibleToAccounts")]
-    public List<string> VisibleToAccounts { get; set; }
+    public List<long> VisibleToAccounts { get; set; }
 
     [JsonPropertyName("isAutoInstallDuringOSUpgrade")]
     public bool IsAutoInstallDuringOSUpgrade { get; set; }

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/RaidController.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/RaidController.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/RecipientSpecifications.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/RecipientSpecifications.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/Response.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/Response.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System.Collections.Generic;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/ShippingLabel.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/ShippingLabel.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using Microsoft.Devices.HardwareDevCenterManager.Utility;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/ShippingLabel.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/ShippingLabel.cs
@@ -127,6 +127,16 @@ public class ShippingLabel : IArtifact
                 Console.WriteLine("               flooringBuildNumber: " + Targeting.CoEngDriverPublishInfo.FlooringBuildNumber);
                 Console.WriteLine("               ceilingBuildNumber:  " + Targeting.CoEngDriverPublishInfo.CeilingBuildNumber);
             }
+
+            //  visible to accounts
+            if (PublishingSpecifications?.VisibleToAccounts != null)
+            {
+                Console.WriteLine("           visibleToAccounts:");
+                foreach (long account in PublishingSpecifications?.VisibleToAccounts)
+                {
+                    Console.WriteLine($"            {account}");
+                }
+            }
         }
 
         Console.WriteLine("         Links:");

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/StorageController.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/StorageController.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/Submission.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/Submission.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using Microsoft.Devices.HardwareDevCenterManager.Utility;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/Svvp.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/Svvp.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System.Text.Json.Serialization;

--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/Targeting.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/Targeting.cs
@@ -1,7 +1,7 @@
 ﻿/*++
     Copyright (c) Microsoft Corporation. All rights reserved.
 
-    Licensed under the MIT license. See LICENSE file in the project root for full license information.  
+    Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
 using System.Collections.Generic;


### PR DESCRIPTION
# Why
Shipping labels in some scenarios could not be retrieved or created when IDs were type `long`.

# What Changed
- Update `CoEngDriverPublishInfo`, 
  - Add `[JsonConverter(typeof(LongToStringJsonConverter))]` to `FlooringBuildNumber` and `CeilingBuildNumber`.

- Update `Product`
  - Add `SourceProductId` and `SourcePublisherId` with `[JsonConverter(typeof(LongToStringJsonConverter))]`.
  - Add `Links` and `Message`.

- Update `PublishingSpecifications`
  - Change `VisibleToAccounts` from `List<string>` to `List<long>` to match Dashboard documentation.

- Update `<Version>` to `3.0.17`

- Update packages to latest stable versions.

- General code cleanup.
