### PR TITLE
Update Svvp MaxProcessors and MaxMemory with LongToStringJsonConverter

### DIFF
--- a/src/Microsoft.Devices.HardwareDevCenterManager/Models/Svvp.cs
+++ b/src/Microsoft.Devices.HardwareDevCenterManager/Models/Svvp.cs
@@ -4,15 +4,18 @@
     Licensed under the MIT license. See LICENSE file in the project root for full license information.
 --*/
 
+using Microsoft.Devices.HardwareDevCenterManager.Utility;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Devices.HardwareDevCenterManager.DevCenterApi;
 
 public class Svvp
 {
+    [JsonConverter(typeof(LongToStringJsonConverter))]
     [JsonPropertyName("maxProcessors")]
     public string MaxProcessors { get; set; }
 
+    [JsonConverter(typeof(LongToStringJsonConverter))]
     [JsonPropertyName("maxMemory")]
     public string MaxMemory { get; set; }
 }


### PR DESCRIPTION
# Why
Issue #36 

For class Svvp, MaxProcessors and MaxMemory also need to add [JsonConverter(typeof(LongToStringJsonConverter))]. Or else it will have issue "The JSON value could not be converted to System.String. Path: $.additionalAttributes.svvp.maxProcessors" when maxProcessors or MaxMemory has integer value.

Originally posted by @hpe-billwang in https://github.com/microsoft/devices-hardware-dev-center-manager/pull/35#issuecomment-2933321212

# What Changed
- Update `Svvp` `MaxProcessors` and `MaxMemory` with `LongToStringJsonConverter`

# How Tested
Visual Studio Test Explorer

Closes #36 